### PR TITLE
#15108 issue: "Non Panic Task error" is not an internal error

### DIFF
--- a/dev/changelog/46.0.0.md
+++ b/dev/changelog/46.0.0.md
@@ -19,7 +19,11 @@ under the License.
 
 # Apache DataFusion 46.0.0 Changelog
 
-This release consists of 283 commits from 80 contributors. See credits at the end of this changelog for more information.
+This release consists of 288 commits from 79 contributors. See credits at the end of this changelog for more information.
+
+Please see the [Upgrade Guide] for help updating to DataFusion `46.0.0`
+
+[upgrade guide]: https://datafusion.apache.org/library-user-guide/upgrading.html#datafusion-46-0-0
 
 **Breaking changes:**
 
@@ -102,6 +106,8 @@ This release consists of 283 commits from 80 contributors. See credits at the en
 - Examples: boundary analysis example for `AND/OR` conjunctions [#14735](https://github.com/apache/datafusion/pull/14735) (clflushopt)
 - Allow setting the recursion limit for sql parsing [#14756](https://github.com/apache/datafusion/pull/14756) (cetra3)
 - Document SQL literal syntax and escaping [#14934](https://github.com/apache/datafusion/pull/14934) (alamb)
+- Prepare for 46.0.0 release: Version and Changelog [#14903](https://github.com/apache/datafusion/pull/14903) (xudong963)
+- MINOR fix(docs): set the proper link for dev-env setup in contrib guide [#14960](https://github.com/apache/datafusion/pull/14960) (clflushopt)
 
 **Other:**
 
@@ -319,25 +325,33 @@ This release consists of 283 commits from 80 contributors. See credits at the en
 - refactor(properties): Split properties.rs into smaller modules [#14925](https://github.com/apache/datafusion/pull/14925) (Standing-Man)
 - Fix failing extended `sqlite`test on main / update `datafusion-testing` pin [#14940](https://github.com/apache/datafusion/pull/14940) (alamb)
 - Revert Datafusion-cli: Redesign the datafusion-cli execution and print, make it totally streaming printing without memory overhead [#14948](https://github.com/apache/datafusion/pull/14948) (alamb)
+- Remove invalid bug reproducer. [#14950](https://github.com/apache/datafusion/pull/14950) (wiedld)
+- Improve documentation for `DataSourceExec`, `FileScanConfig`, `DataSource` etc [#14941](https://github.com/apache/datafusion/pull/14941) (alamb)
+- Do not swap with projection when file is partitioned [#14956](https://github.com/apache/datafusion/pull/14956) (blaginin)
+- Minor: Add more projection pushdown tests, clarify comments [#14963](https://github.com/apache/datafusion/pull/14963) (alamb)
+- Update labeler components [#14942](https://github.com/apache/datafusion/pull/14942) (alamb)
+- Deprecate `Expr::Wildcard` [#14959](https://github.com/apache/datafusion/pull/14959) (linhr)
 
 ## Credits
 
 Thank you to everyone who contributed to this release. Here is a breakdown of commits (PRs merged) per contributor.
 
 ```
-    35	Andrew Lamb
+    38	Andrew Lamb
+    35	dependabot[bot]
     14	Piotr Findeisen
     10	Matthijs Brobbel
     10	logan-keede
      9	Bruce Ritchie
+     9	xudong.w
      8	Jay Zhan
      8	Qi Zhu
-     8	xudong.w
      6	Adam Gutglick
      6	Joseph Koshakow
      5	Ian Lai
      5	Lordworms
      5	Simon Vandel Sillesen
+     5	wiedld
      5	zjregee
      4	Dmitrii Blaginin
      4	Kristin Cowalcijk
@@ -345,7 +359,6 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
      4	Yongting You
      4	irenjj
      4	oznur-synnada
-     4	wiedld
      3	Andy Yen
      3	Jax Liu
      3	Oleks V

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -280,6 +280,8 @@ Verify that the Cargo.toml in the tarball contains the correct version
 (cd datafusion/physical-plan && cargo publish)
 (cd datafusion/physical-optimizer && cargo publish)
 (cd datafusion/catalog && cargo publish)
+(cd datafusion/datasource && cargo publish)
+(cd datafusion/catalog-listing && cargo publish)
 (cd datafusion/functions-table && cargo publish)
 (cd datafusion/core && cargo publish)
 (cd datafusion/proto-common && cargo publish)


### PR DESCRIPTION
* [branch-46] Update changelog for backports to 46.0.0 (#14977)

* Add note about upgrade guide into the release notes (#14979)

* Add new crates

---------

## Which issue does this PR close?
The issue was to change the internal error to execution error
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

The main reason for changing the error type from an internal error (internal_err!()) to an execution error is to improve the accuracy of error classification.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
changed the error from internal_error! to exec_error!
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
No
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
